### PR TITLE
ci: run the CI on PRs, too.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
 name: "Build and check HTML"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+name: "Build and check HTML"
 on:
   workflow_dispatch:
   push:
@@ -5,7 +6,9 @@ on:
       - main
   pull_request:
 
-name: "Build and check HTML"
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
Only the `build` step; deployment only runs on `main`.

Since the CI takes quite long, this might not be desirable. On the other hand, previous runs are cancelled and the repo generally low activity.